### PR TITLE
Update styles when using warp command

### DIFF
--- a/frontend/static/yw/javascript/chat.js
+++ b/frontend/static/yw/javascript/chat.js
@@ -185,6 +185,16 @@ var client_commands = {
 		state.worldModel.pathname = "/" + address;
 		ws_path = createWsPath();
 		w.changeSocket(ws_path);
+		getWorldProps(address, "style", function(style, error) {
+			if(!error) {
+    			styles.member = style.member;
+    			styles.owner = style.owner;
+    			styles.public = style.public;
+    			styles.text = style.text;
+			}
+			menu_color(styles.menu);
+			w.redraw();
+		});
 		clientChatResponse("Switching to world: \"" + address + "\"");
 	},
 	night: function() {


### PR DESCRIPTION
Uses the `getWorldProps()` function to update world styles when running the /warp command in chat.